### PR TITLE
Bower recipe for win-64 (fix path too long error)

### DIFF
--- a/bower/.binstar.yml
+++ b/bower/.binstar.yml
@@ -4,7 +4,7 @@ user: javascript
 platform:
   - linux-32
   - linux-64
-  - osx-64
+  # - osx-64
   - win-32
   - win-64
 

--- a/bower/.binstar.yml
+++ b/bower/.binstar.yml
@@ -12,7 +12,7 @@ install:
   - conda config -f --add channels https://conda.binstar.org/javascript
 
 engine:
-  - python=2
+  - python=3
 
 script:
   - conda build .

--- a/bower/.binstar.yml
+++ b/bower/.binstar.yml
@@ -12,7 +12,7 @@ install:
   - conda config -f --add channels https://conda.binstar.org/javascript
 
 engine:
-  - python=3
+  - python=2
 
 script:
   - conda build .

--- a/bower/bld.bat
+++ b/bower/bld.bat
@@ -1,15 +1,14 @@
 REM needed to ensure 2.3.0 see https://github.com/npm/npm/issues/4080
 CALL npm install -g --upgrade npm@next
-CALL npm install -g flatten-packages
+CALL npm install -g fenestrate
 CALL npm install -g %PKG_NAME%@%PKG_VERSION%
 
-CALL cd %PREFIX%
-CALL npm dedupe
-CALL npm shrinkwrap
-CALL flatten-packages
+CALL cd %PREFIX%/bower
+CALL fenestrate make .
+CALL fenestrate rewrite .
 
 REM Remove flatten-packages and npm so it's not accidentally packaged up
-CALL npm uninstall -g flatten-packages
+CALL npm uninstall -g fenestrate
 CALL npm uninstall -g npm
 
 REM Exit zero because the npm uninstall, while successful, will exit with an

--- a/bower/bld.bat
+++ b/bower/bld.bat
@@ -1,8 +1,15 @@
 REM needed to ensure 2.3.0 see https://github.com/npm/npm/issues/4080
 CALL npm install -g --upgrade npm@next
+CALL npm install -g flatten-packages
 CALL npm install -g %PKG_NAME%@%PKG_VERSION%
 
-REM Remove npm so it's not accidentally packaged up
+CALL cd %PREFIX%
+CALL npm dedupe
+CALL npm shrinkwrap
+CALL flatten-packages
+
+REM Remove flatten-packages and npm so it's not accidentally packaged up
+CALL npm uninstall -g flatten-packages
 CALL npm uninstall -g npm
 
 REM Exit zero because the npm uninstall, while successful, will exit with an

--- a/bower/bld.bat
+++ b/bower/bld.bat
@@ -1,14 +1,15 @@
 REM needed to ensure 2.3.0 see https://github.com/npm/npm/issues/4080
 CALL npm install -g --upgrade npm@next
-CALL npm install -g fenestrate
+CALL npm install -g flatten-packages
 CALL npm install -g %PKG_NAME%@%PKG_VERSION%
 
-CALL cd %PREFIX%\node_modules\bower
-CALL fenestrate make .
-CALL fenestrate rewrite .
+CALL cd %PREFIX%
+CALL npm dedupe
+CALL npm shrinkwrap
+CALL flatten-packages
 
 REM Remove flatten-packages and npm so it's not accidentally packaged up
-CALL npm uninstall -g fenestrate
+CALL npm uninstall -g flatten-packages
 CALL npm uninstall -g npm
 
 REM Exit zero because the npm uninstall, while successful, will exit with an

--- a/bower/bld.bat
+++ b/bower/bld.bat
@@ -3,7 +3,7 @@ CALL npm install -g --upgrade npm@next
 CALL npm install -g fenestrate
 CALL npm install -g %PKG_NAME%@%PKG_VERSION%
 
-CALL cd %PREFIX%/bower
+CALL cd %PREFIX%\node_modules\bower
 CALL fenestrate make .
 CALL fenestrate rewrite .
 


### PR DESCRIPTION
will eliminate duplicated dependencies and flatten them into a single node_modules folder.
