### PR TITLE
Fix logic for iojs build dependencies selector

### DIFF
--- a/iojs/meta.yaml
+++ b/iojs/meta.yaml
@@ -27,7 +27,7 @@ source:
 
 requirements:
   build:
-    - python [win32 and win64]
+    - python [win]
 
 test:
   commands:


### PR DESCRIPTION
The selectors are evaluated as Python, so "win32 and win64" is never True,
since they are mutually exclusive.